### PR TITLE
fix: reduce of empty array with no initial value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ async function extractReleaseNotes(changelogFile, prerelease) {
             }
         }
     }
-    let releaseNotes = lines.reduce((previousValue, currentValue) => previousValue + eol + currentValue)
+    let releaseNotes = lines.reduce((previousValue, currentValue) => previousValue + eol + currentValue,'')
     releaseNotes = trimEmptyLinesTop(releaseNotes)
     releaseNotes = trimEmptyLinesBottom(releaseNotes)
     return releaseNotes


### PR DESCRIPTION

This error is raised when an empty array is provided because no initial value can be returned in that case.

closes #339